### PR TITLE
Fix Docker config for Flask hot reload

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,18 @@ services:
     container_name: flask-python_app
     env_file:
       - ./db/.env
+    environment:
+      - FLASK_APP=wsgi.py
+      - FLASK_ENV=development
+      - FLASK_RUN_PORT=8000
     networks:
       - flask-network
     volumes:
       - ./app:/app
     depends_on:
       db:
-        condition: service_healthy 
-    command: gunicorn -w 4 -b 0.0.0.0:8000 wsgi:app
+        condition: service_healthy
+    command: flask run --host=0.0.0.0 --reload
   
   web:
     image: nginx:latest


### PR DESCRIPTION
## Summary
- enable Flask hot reloading

## Testing
- `python -m py_compile app/app.py`
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848609bfc6c8325ba4fbe20e1753583